### PR TITLE
DEV-30762 Allow disabling of alert manager creation

### DIFF
--- a/conf/defaults.ini
+++ b/conf/defaults.ini
@@ -748,6 +748,9 @@ global_alert_rule = -1
 # Enable the Unified Alerting sub-system and interface. When enabled we'll migrate all of your alert rules and notification channels to the new system. New alert rules will be created and your notification channels will be converted into an Alertmanager configuration. Previous data is preserved to enable backwards compatibility but new data is removed when switching. When this configuration section and flag are not defined, the state is defined at runtime. See the documentation for more details.
 enabled =
 
+# Enable Multiorg alert manager (including periodic config sync)
+alert_manager_enabled = true
+
 # Comma-separated list of organization IDs for which to disable unified alerting. Only supported if unified alerting is enabled.
 disabled_orgs =
 

--- a/conf/sample.ini
+++ b/conf/sample.ini
@@ -730,6 +730,9 @@
 #Enable the Unified Alerting sub-system and interface. When enabled we'll migrate all of your alert rules and notification channels to the new system. New alert rules will be created and your notification channels will be converted into an Alertmanager configuration. Previous data is preserved to enable backwards compatibility but new data is removed.```
 ;enabled = true
 
+# Enable Multiorg alert manager (including periodic config sync)
+;alert_manager_enabled = true
+
 # Comma-separated list of organization IDs for which to disable unified alerting. Only supported if unified alerting is enabled.
 ;disabled_orgs =
 

--- a/pkg/services/ngalert/ngalert.go
+++ b/pkg/services/ngalert/ngalert.go
@@ -105,16 +105,18 @@ func (ng *AlertNG) init() error {
 		Logger:          ng.Log,
 	}
 
-	decryptFn := ng.SecretsService.GetDecryptedValue
-	multiOrgMetrics := ng.Metrics.GetMultiOrgAlertmanagerMetrics()
-	ng.MultiOrgAlertmanager, err = notifier.NewMultiOrgAlertmanager(ng.Cfg, store, store, ng.KVStore, decryptFn, multiOrgMetrics, ng.NotificationService, log.New("ngalert.multiorg.alertmanager"))
-	if err != nil {
-		return err
-	}
+	if ng.Cfg.UnifiedAlerting.AlertManagerEnabled {
+		decryptFn := ng.SecretsService.GetDecryptedValue
+		multiOrgMetrics := ng.Metrics.GetMultiOrgAlertmanagerMetrics()
+		ng.MultiOrgAlertmanager, err = notifier.NewMultiOrgAlertmanager(ng.Cfg, store, store, ng.KVStore, decryptFn, multiOrgMetrics, ng.NotificationService, log.New("ngalert.multiorg.alertmanager"))
+		if err != nil {
+			return err
+		}
 
-	// Let's make sure we're able to complete an initial sync of Alertmanagers before we start the alerting components.
-	if err := ng.MultiOrgAlertmanager.LoadAndSyncAlertmanagersForOrgs(context.Background()); err != nil {
-		return err
+		// Let's make sure we're able to complete an initial sync of Alertmanagers before we start the alerting components.
+		if err := ng.MultiOrgAlertmanager.LoadAndSyncAlertmanagersForOrgs(context.Background()); err != nil {
+			return err
+		}
 	}
 
 	schedCfg := schedule.SchedulerCfg{
@@ -178,9 +180,13 @@ func (ng *AlertNG) Run(ctx context.Context) error {
 			return ng.schedule.Run(subCtx)
 		})
 	}
-	children.Go(func() error {
-		return ng.MultiOrgAlertmanager.Run(subCtx)
-	})
+	if ng.Cfg.UnifiedAlerting.AlertManagerEnabled {
+		children.Go(func() error {
+			return ng.MultiOrgAlertmanager.Run(subCtx)
+		})
+	} else {
+		ng.Log.Debug("Alert manager is disabled")
+	}
 	return children.Wait()
 }
 

--- a/pkg/setting/setting_unified_alerting.go
+++ b/pkg/setting/setting_unified_alerting.go
@@ -66,6 +66,7 @@ type UnifiedAlertingSettings struct {
 	DefaultConfiguration           string
 	Enabled                        *bool // determines whether unified alerting is enabled. If it is nil then user did not define it and therefore its value will be determined during migration. Services should not use it directly.
 	DisabledOrgs                   map[int64]struct{}
+	AlertManagerEnabled            bool // LOGZ.IO GRAFANA CHANGE :: DEV-30762 - disable creation of alert managers by config
 }
 
 // IsEnabled returns true if UnifiedAlertingSettings.Enabled is either nil or true.
@@ -215,6 +216,8 @@ func (cfg *Cfg) ReadUnifiedAlertingSettings(iniFile *ini.File) error {
 		uaMinInterval = legacyMinInterval
 	}
 	uaCfg.MinInterval = uaMinInterval
+
+	uaCfg.AlertManagerEnabled = ua.Key("alert_manager_enabled").MustBool(true)
 
 	cfg.UnifiedAlerting = uaCfg
 	return nil


### PR DESCRIPTION
According to the design of alert manager (Grafana 8 unified alerting) we want to have 2 separate group of grafana instances:

evaluators

alert managers

By default, each grafana instance will create alert managers for all organizations. This is not ideal because we do not need alert managers for evaluator grafana instances.

As a part of this change, we want to add a configuration which will allow to enable/disable creation of alert managers in Grafana BE.